### PR TITLE
Unify StaticArray, Position, Size, and Bounds hierarchies

### DIFF
--- a/source/containers/EStaticArray.hpp
+++ b/source/containers/EStaticArray.hpp
@@ -67,6 +67,13 @@ namespace EToolkit{
 			 */
 			DataType& operator[](unsigned int index);
 
+			/**
+			 * @brief Access element at given index (read-only for const objects).
+			 * @param index Position in the array.
+			 * @return Const reference to the data at the index.
+			 */
+			const DataType& operator[](unsigned int index) const;
+
 			/*
 			 * @description: Operator that check if the 'size' and all elements values are equals to elements of the given 'other' vector.
 			 * @return: True if yes or false otherwise.
@@ -205,6 +212,15 @@ EToolkit::StaticArray<DataType>& EToolkit::StaticArray<DataType>::operator=(cons
 
 template<class DataType>
 DataType& EToolkit::StaticArray<DataType>::operator[](unsigned int index){
+	if(index >= size){
+		throw OutOfBoundsException();
+	}else{
+		return data[index];
+	}
+}
+
+template<class DataType>
+const DataType& EToolkit::StaticArray<DataType>::operator[](unsigned int index) const {
 	if(index >= size){
 		throw OutOfBoundsException();
 	}else{

--- a/source/controls/EControl.cpp
+++ b/source/controls/EControl.cpp
@@ -111,15 +111,15 @@ EToolkit::Position2i EToolkit::Control::getPosition() const{
 
 void EToolkit::Control::setPosition(const Position2i& position){
 	Bounds2i bounds = getBounds();
-	bounds.x = position.x;
-	bounds.y = position.y;
+	bounds.setX(position.getX());
+	bounds.setY(position.getY());
 	setBounds(bounds);
 }
 
 void EToolkit::Control::setPosition(int x, int y){
 	Bounds2i bounds = getBounds();
-	bounds.x = x;
-	bounds.y = y;
+	bounds.setX(x);
+	bounds.setY(y);
 	setBounds(bounds);
 }
 
@@ -129,15 +129,15 @@ EToolkit::Size2i EToolkit::Control::getSize() const{
 
 void EToolkit::Control::setSize(const Size2i& size){
 	Bounds2i bounds = getBounds();
-	bounds.width = size.width;
-	bounds.height = size.height;
+	bounds.setWidth(size.getWidth());
+	bounds.setHeight(size.getHeight());
 	setBounds(bounds);
 }
 
 void EToolkit::Control::setSize(int width, int height){
 	Bounds2i bounds = getBounds();
-	bounds.width = width;
-	bounds.height = height;
+	bounds.setWidth(width);
+	bounds.setHeight(height);
 	setBounds(bounds);
 }
 
@@ -156,7 +156,7 @@ EToolkit::Bounds2i EToolkit::Control::getBounds() const{
 
 void EToolkit::Control::setBounds(const Bounds2i& bounds){
 	if(data != nullptr && data->hwnd != NULL){
-		if(::MoveWindow(data->hwnd, bounds.x, bounds.y, bounds.width, bounds.height, TRUE) == 0){
+		if(::MoveWindow(data->hwnd, bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), TRUE) == 0){
 			throw WindowsAPIException("invalid 'MoveWindow'");
 		}
 	}

--- a/source/geometry/EBounds1.hpp
+++ b/source/geometry/EBounds1.hpp
@@ -1,3 +1,8 @@
+/**
+ * @file EBounds1.hpp
+ * @brief Contains Bounds1 template class.
+ */
+
 #ifndef EBOUNDS1_HPP
 #define EBOUNDS1_HPP
 
@@ -5,41 +10,76 @@
 #include "ESize1.hpp"
 
 /*
- * @description: Evandro's Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent a object with 1 dimensional position and size.
-	 * @note: 'Bounds1Type' must be numeric.
-	 */
-	template<class Bounds1Type>
-	class Bounds1 : public Position1<Bounds1Type>, public Size1<Bounds1Type>{
-		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'x' and 'width' values.
-			 * @return: None.
-			 */
-			Bounds1(Bounds1Type x = 0, Bounds1Type width = 0);
+    /**
+     * @class Bounds1
+     * @brief Represents a 1-dimensional bounds (position + size).
+     * @tparam Bounds1Type Numeric type used for coordinates and dimensions.
+     *
+     * Inherits from Position1 and Size1. Can be used as a StaticArray through Position1 or Size1 base.
+     *
+     * @note Internally, allocates a single contiguous array of 2 elements:
+     *       index 0 stores the x coordinate (position),
+     *       index 1 stores the width (size).
+     */
+    template<class Bounds1Type>
+    class Bounds1 : virtual public Position1<Bounds1Type>, virtual public Size1<Bounds1Type> {
+    public:
+    	using Position1<Bounds1Type>::getX; ///< Resolves multiple inheritance ambiguity, specifies getX comes from Position3
+    	using Position1<Bounds1Type>::setX; ///< Resolves multiple inheritance ambiguity, specifies setX comes from Position3
+    	using Size1<Bounds1Type>::getWidth; ///< Resolves multiple inheritance ambiguity, specifies getWidth comes from Size3
+    	using Size1<Bounds1Type>::setWidth; ///< Resolves multiple inheritance ambiguity, specifies setWidth comes from Size3
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
-			 */
-			~Bounds1();
-	};
+        /**
+         * @brief Constructs a Bounds1 object with given position and size.
+         * @param x Initial x coordinate (default = 0).
+         * @param width Initial width value (default = 0).
+         */
+        Bounds1(Bounds1Type x = 0, Bounds1Type width = 0);
 
-	typedef Bounds1<int> Bounds1i;
+        /**
+         * @brief Constructs a Bounds1 object from a Position1 object and width value equals to 0.
+         * @param position Position1 object to copy x coordinate from.
+         */
+        Bounds1(const Position1<Bounds1Type>& position);
+
+        /**
+         * @brief Constructs a Bounds1 object from a Size1 object and x value equals to 0.
+         * @param size Size1 object to copy width from.
+         */
+        Bounds1(const Size1<Bounds1Type>& size);
+
+        /**
+         * @brief Virtual destructor.
+         */
+        virtual ~Bounds1() = default;
+    };
+
+    typedef Bounds1<int> Bounds1i; ///< Typedef for integer bounds1.
 }
 
 template<class Bounds1Type>
 EToolkit::Bounds1<Bounds1Type>::Bounds1(Bounds1Type x, Bounds1Type width) :
-	Position1<Bounds1Type>(x), Size1<Bounds1Type>(width){
+	StaticArray<Bounds1Type>({x, width})
+{
 
 }
 
 template<class Bounds1Type>
-EToolkit::Bounds1<Bounds1Type>::~Bounds1(){
+EToolkit::Bounds1<Bounds1Type>::Bounds1(const Position1<Bounds1Type>& position) :
+	StaticArray<Bounds1Type>({position.getX(), 0})
+{
+
+}
+
+template<class Bounds1Type>
+EToolkit::Bounds1<Bounds1Type>::Bounds1(const Size1<Bounds1Type>& size) :
+	StaticArray<Bounds1Type>({0, size.getWidth()})
+{
 
 }
 

--- a/source/geometry/EBounds2.hpp
+++ b/source/geometry/EBounds2.hpp
@@ -1,45 +1,94 @@
+/**
+ * @file EBounds2.hpp
+ * @brief Contains Bounds2 template class.
+ */
+
 #ifndef EBOUNDS2_HPP
 #define EBOUNDS2_HPP
 
+#include "EBounds1.hpp"
 #include "EPosition2.hpp"
 #include "ESize2.hpp"
 
 /*
- * @description: Evandro's Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent a object with 2 dimensional position and size.
-	 * @note: 'Bounds2Type' must be numeric.
-	 */
-	template<class Bounds2Type>
-	class Bounds2 : public Position2<Bounds2Type>, public Size2<Bounds2Type>{
-		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'x', 'y', 'width' and 'height' values.
-			 * @return: None.
-			 */
-			Bounds2(Bounds2Type x = 0, Bounds2Type y = 0, Bounds2Type width = 0, Bounds2Type height = 0);
+    /**
+     * @class Bounds2
+     * @brief Represents a 2-dimensional bounds (position + size).
+     * @tparam Bounds2Type Numeric type used for coordinates and dimensions.
+     *
+     * Inherits from Bounds1, Position2 and Size2. Can be used as a StaticArray through Position2 or Size2 bases.
+     *
+     * @note Internally, allocates a single contiguous array of 4 elements:
+     *       index 0 stores x coordinate,
+     *       index 1 stores y coordinate,
+     *       index 2 stores width,
+     *       index 3 stores height.
+     */
+    template<class Bounds2Type>
+    class Bounds2 : public Bounds1<Bounds2Type>, virtual public Position2<Bounds2Type>, virtual public Size2<Bounds2Type> {
+    public:
+    	using Position2<Bounds2Type>::getX; ///< Resolves multiple inheritance ambiguity, specifies getX comes from Position3
+    	using Position2<Bounds2Type>::setX; ///< Resolves multiple inheritance ambiguity, specifies setX comes from Position3
+    	using Position2<Bounds2Type>::getY; ///< Resolves multiple inheritance ambiguity, specifies getY comes from Position3
+    	using Position2<Bounds2Type>::setY; ///< Resolves multiple inheritance ambiguity, specifies setY comes from Position3
+    	using Size2<Bounds2Type>::getWidth; ///< Resolves multiple inheritance ambiguity, specifies getWidth comes from Size3
+    	using Size2<Bounds2Type>::setWidth; ///< Resolves multiple inheritance ambiguity, specifies setWidth comes from Size3
+    	using Size2<Bounds2Type>::getHeight; ///< Resolves multiple inheritance ambiguity, specifies getHeight comes from Size3
+    	using Size2<Bounds2Type>::setHeight; ///< Resolves multiple inheritance ambiguity, specifies setHeight comes from Size3
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
-			 */
-			~Bounds2();
-	};
+    	/**
+    	 * @brief Constructs a Bounds2 object with given position and size.
+    	 * @param x Initial x coordinate (default = 0).
+    	 * @param y Initial y coordinate (default = 0).
+    	 * @param width Initial width (default = 0).
+    	 * @param height Initial height (default = 0).
+    	 */
+    	Bounds2(Bounds2Type x = 0, Bounds2Type y = 0, Bounds2Type width = 0, Bounds2Type height = 0);
 
-	typedef Bounds2<int> Bounds2i;
+    	/**
+    	 * @brief Constructs a Bounds2 object from a Position2 object and width and height values equal to 0.
+    	 * @param position Position2 object to copy x and y coordinates from.
+    	 */
+    	Bounds2(const Position2<Bounds2Type>& position);
+
+    	/**
+    	 * @brief Constructs a Bounds2 object from a Size2 object and x and y values equal to 0.
+    	 * @param size Size2 object to copy width and height from.
+    	 */
+    	Bounds2(const Size2<Bounds2Type>& size);
+
+        /**
+         * @brief Virtual destructor.
+         */
+        virtual ~Bounds2() = default;
+    };
+
+    typedef Bounds2<int> Bounds2i; ///< Typedef for integer bounds2.
 }
 
 template<class Bounds2Type>
 EToolkit::Bounds2<Bounds2Type>::Bounds2(Bounds2Type x, Bounds2Type y, Bounds2Type width, Bounds2Type height) :
-	Position2<Bounds2Type>(x, y), Size2<Bounds2Type>(width, height){
+	StaticArray<Bounds2Type>({x, y, width, height})
+{
 
 }
 
 template<class Bounds2Type>
-EToolkit::Bounds2<Bounds2Type>::~Bounds2(){
+EToolkit::Bounds2<Bounds2Type>::Bounds2(const Position2<Bounds2Type>& position) :
+	StaticArray<Bounds2Type>({position.getX(), position.getY(), 0, 0})
+{
+
+}
+
+template<class Bounds2Type>
+EToolkit::Bounds2<Bounds2Type>::Bounds2(const Size2<Bounds2Type>& size) :
+	StaticArray<Bounds2Type>({0, 0, size.getWidth(), size.getHeight()})
+{
 
 }
 

--- a/source/geometry/EBounds3.hpp
+++ b/source/geometry/EBounds3.hpp
@@ -1,45 +1,102 @@
+/**
+ * @file EBounds3.hpp
+ * @brief Contains Bounds3 template class.
+ */
+
 #ifndef EBOUNDS3_HPP
 #define EBOUNDS3_HPP
 
+#include "EBounds2.hpp"
 #include "EPosition3.hpp"
 #include "ESize3.hpp"
 
 /*
- * @description: Evandro's Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent a object with 3 dimensional position and size.
-	 * @note: 'Bounds3Type' must be numeric.
-	 */
-	template<class Bounds3Type>
-	class Bounds3 : public Position3<Bounds3Type>, public Size3<Bounds3Type>{
-		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'x', 'y', 'z', 'width', 'height' and 'depth' values.
-			 * @return: None.
-			 */
-			Bounds3(Bounds3Type x = 0, Bounds3Type y = 0, Bounds3Type z = 0, Bounds3Type width = 0, Bounds3Type height = 0, Bounds3Type depth = 0);
+    /**
+     * @class Bounds3
+     * @brief Represents a 3-dimensional bounds (position + size).
+     * @tparam Bounds3Type Numeric type used for coordinates and dimensions.
+     *
+     * Inherits from Bounds2, Position3 and Size3. Can be used as a StaticArray through Position3 or Size3 bases.
+     *
+     * @note Internally, allocates a single contiguous array of 6 elements:
+     *       index 0 stores x coordinate,
+     *       index 1 stores y coordinate,
+     *       index 2 stores z coordinate,
+     *       index 3 stores width,
+     *       index 4 stores height,
+     *       index 5 stores depth.
+     */
+    template<class Bounds3Type>
+    class Bounds3 : public Bounds2<Bounds3Type>, virtual public Position3<Bounds3Type>, virtual public Size3<Bounds3Type> {
+    public:
+    	using Position3<Bounds3Type>::getX;  ///< Resolves multiple inheritance ambiguity, specifies getX comes from Position3
+    	using Position3<Bounds3Type>::setX;  ///< Resolves multiple inheritance ambiguity, specifies setX comes from Position3
+    	using Position3<Bounds3Type>::getY;  ///< Resolves multiple inheritance ambiguity, specifies getY comes from Position3
+    	using Position3<Bounds3Type>::setY;  ///< Resolves multiple inheritance ambiguity, specifies setY comes from Position3
+    	using Position3<Bounds3Type>::getZ;  ///< Resolves multiple inheritance ambiguity, specifies getZ comes from Position3
+    	using Position3<Bounds3Type>::setZ;  ///< Resolves multiple inheritance ambiguity, specifies setZ comes from Position3
+    	using Size3<Bounds3Type>::getWidth;  ///< Resolves multiple inheritance ambiguity, specifies getWidth  comes from Size3
+    	using Size3<Bounds3Type>::setWidth;  ///< Resolves multiple inheritance ambiguity, specifies setWidth  comes from Size3
+    	using Size3<Bounds3Type>::getHeight; ///< Resolves multiple inheritance ambiguity, specifies getHeight comes from Size3
+    	using Size3<Bounds3Type>::setHeight; ///< Resolves multiple inheritance ambiguity, specifies setHeight comes from Size3
+    	using Size3<Bounds3Type>::getDepth;  ///< Resolves multiple inheritance ambiguity, specifies getDepth  comes from Size3
+    	using Size3<Bounds3Type>::setDepth;  ///< Resolves multiple inheritance ambiguity, specifies setDepth  comes from Size3
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
-			 */
-			~Bounds3();
-	};
+    	/**
+    	 * @brief Constructs a Bounds3 object with given position and size.
+    	 * @param x Initial x coordinate (default = 0).
+    	 * @param y Initial y coordinate (default = 0).
+    	 * @param z Initial z coordinate (default = 0).
+    	 * @param width Initial width (default = 0).
+    	 * @param height Initial height (default = 0).
+    	 * @param depth Initial depth (default = 0).
+    	 */
+    	Bounds3(Bounds3Type x = 0, Bounds3Type y = 0, Bounds3Type z = 0, Bounds3Type width = 0, Bounds3Type height = 0, Bounds3Type depth = 0);
 
-	typedef Bounds3<int> Bounds3i;
+    	/**
+    	 * @brief Constructs a Bounds3 object from a Position3 object and width, height and depth values equal to 0.
+    	 * @param position Position3 object to copy x, y, z coordinates from.
+    	 */
+    	Bounds3(const Position3<Bounds3Type>& position);
+
+    	/**
+    	 * @brief Constructs a Bounds3 object from a Size3 object and x, y and z values equal to 0.
+    	 * @param size Size3 object to copy width, height and depth from.
+    	 */
+    	Bounds3(const Size3<Bounds3Type>& size);
+
+        /**
+         * @brief Virtual destructor.
+         */
+        virtual ~Bounds3() = default;
+    };
+
+    typedef Bounds3<int> Bounds3i; ///< Typedef for integer bounds3.
 }
 
 template<class Bounds3Type>
 EToolkit::Bounds3<Bounds3Type>::Bounds3(Bounds3Type x, Bounds3Type y, Bounds3Type z, Bounds3Type width, Bounds3Type height, Bounds3Type depth) :
-	Position3<Bounds3Type>(x, y, z), Size3<Bounds3Type>(width, height, depth){
+	StaticArray<Bounds3Type>({x, y, z, width, height, depth})
+{
 
 }
 
 template<class Bounds3Type>
-EToolkit::Bounds3<Bounds3Type>::~Bounds3(){
+EToolkit::Bounds3<Bounds3Type>::Bounds3(const Position3<Bounds3Type>& position) :
+	StaticArray<Bounds3Type>({position.getX(), position.getY(), position.getZ(), 0, 0, 0})
+{
+
+}
+
+template<class Bounds3Type>
+EToolkit::Bounds3<Bounds3Type>::Bounds3(const Size3<Bounds3Type>& size) :
+	StaticArray<Bounds3Type>({0, 0, 0, size.getWidth(), size.getHeight(), size.getDepth()})
+{
 
 }
 

--- a/source/geometry/EPosition1.hpp
+++ b/source/geometry/EPosition1.hpp
@@ -1,46 +1,81 @@
+/**
+ * @file Position1.hpp
+ * @brief Contains Position1 template class.
+ */
+
 #ifndef EPOSITION1_HPP
 #define EPOSITION1_HPP
 
+#include <EContainer>
+
 /*
- * @description: Evandro's C++ Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent 1 dimensional position.
-	 * @note: 'Position1Type' must be numeric.
+	/**
+	 * @class Position1
+	 * @brief Represents a 1-dimensional position.
+	 * @tparam Position1Type Numeric type used for the coordinate.
+	 *
+	 * Inherits from StaticArray with size 1. Provides access methods to the single coordinate 'x'.
 	 */
 	template<class Position1Type>
-	class Position1{
+	class Position1 : virtual public StaticArray<Position1Type>{
 		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'x' value.
-			 * @return: None.
+			/**
+			 * @brief Default constructor that initializes the object with the given `x` value.
+			 * @param x The initial value for the x coordinate (default = 0).
 			 */
 			Position1(Position1Type x = 0);
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
+			/**
+			 * @brief Virtual destructor.
 			 */
-			~Position1();
+			virtual ~Position1() = default;
 
-		public:
-			Position1Type x;
+			/**
+			 * @brief Get the x coordinate.
+			 * @return The current value of x.
+			 */
+			inline Position1Type& getX();
+
+		    /**
+		     * @brief Get the x coordinate (read-only for const objects).
+		     * @return Constant reference to x.
+		     */
+		    inline const Position1Type& getX() const;
+
+			/**
+			 * @brief Set the x coordinate.
+			 * @param x The value to assign to x.
+			 */
+			inline void setX(const Position1Type& x);
 	};
 
-	typedef Position1<int> Position1i;
+	typedef Position1<int> Position1i; ///< Typedef for integer 1D positions.
 }
 
 template<class Position1Type>
 EToolkit::Position1<Position1Type>::Position1(Position1Type x) :
-	x(x){
-
+	StaticArray<Position1Type>(1){
+	(*this)[0] = x;
 }
 
 template<class Position1Type>
-EToolkit::Position1<Position1Type>::~Position1(){
+inline Position1Type& EToolkit::Position1<Position1Type>::getX(){
+	return (*this)[0];
+}
 
+template<class Position1Type>
+inline const Position1Type& EToolkit::Position1<Position1Type>::getX() const{
+    return (*this)[0];
+}
+
+template<class Position1Type>
+inline void EToolkit::Position1<Position1Type>::setX(const Position1Type& x){
+	(*this)[0] = x;
 }
 
 #endif /* EPOSITION1_HPP */

--- a/source/geometry/EPosition2.hpp
+++ b/source/geometry/EPosition2.hpp
@@ -1,48 +1,83 @@
+/**
+ * @file Position2.hpp
+ * @brief Contains Position2 template class.
+ */
+
 #ifndef EPOSITION2_HPP
 #define EPOSITION2_HPP
 
 #include "EPosition1.hpp"
 
 /*
- * @description: Evandro's C++ Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent 2 dimensional position.
-	 * @note: 'Position2Type' must be numeric.
+	/**
+	 * @class Position2
+	 * @brief Represents a 2-dimensional position.
+	 * @tparam Position2Type Numeric type used for the coordinates.
+	 *
+	 * Inherits from Position1 (x coordinate) and extends it with 'y'.
 	 */
 	template<class Position2Type>
-	class Position2 : public Position1<Position2Type>{
+	class Position2 : virtual public Position1<Position2Type>{
 		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'x' and 'y' values.
-			 * @return: None.
+			/**
+			 * @brief Constructor that initializes the object with the given `x` and `y` values.
+			 * @param x The initial value for the x coordinate (default = 0).
+			 * @param y The initial value for the y coordinate (default = 0).
 			 */
 			Position2(Position2Type x = 0, Position2Type y = 0);
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
+			/**
+			 * @brief Virtual destructor.
 			 */
-			~Position2();
+			virtual ~Position2() = default;
 
-		public:
-			Position2Type y;
+			/**
+			 * @brief Get the y coordinate.
+			 * @return Reference to the current value of y.
+			 */
+			inline Position2Type& getY();
+
+			/**
+			 * @brief Get the y coordinate (read-only for const objects).
+			 * @return Constant reference to y.
+			 */
+			inline const Position2Type& getY() const;
+
+			/**
+			 * @brief Set the y coordinate.
+			 * @param y The value to assign to y.
+			 */
+			inline void setY(const Position2Type& y);
 	};
 
-	typedef Position2<int> Position2i;
+	typedef Position2<int> Position2i; ///< Typedef for integer 2D positions.
 }
 
 template<class Position2Type>
 EToolkit::Position2<Position2Type>::Position2(Position2Type x, Position2Type y) :
-	Position1<Position2Type>(x), y(y){
-
+	StaticArray<Position2Type>(2), Position1<Position2Type>(x){
+	(*this)[0] = x;
+	(*this)[1] = y;
 }
 
 template<class Position2Type>
-EToolkit::Position2<Position2Type>::~Position2(){
+inline Position2Type& EToolkit::Position2<Position2Type>::getY(){
+	return (*this)[1];
+}
 
+template<class Position2Type>
+inline const Position2Type& EToolkit::Position2<Position2Type>::getY() const{
+    return (*this)[1];
+}
+
+template<class Position2Type>
+inline void EToolkit::Position2<Position2Type>::setY(const Position2Type& y){
+	(*this)[1] = y;
 }
 
 #endif /* EPOSITION2_HPP */

--- a/source/geometry/EPosition3.hpp
+++ b/source/geometry/EPosition3.hpp
@@ -1,48 +1,85 @@
+/**
+ * @file Position3.hpp
+ * @brief Contains Position3 template class.
+ */
+
 #ifndef EPOSITION3_HPP
 #define EPOSITION3_HPP
 
 #include "EPosition2.hpp"
 
 /*
- * @description: Evandro's C++ Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent 3 dimensional position.
-	 * @note: 'Position3Type' must be numeric.
+	/**
+	 * @class Position3
+	 * @brief Represents a 3-dimensional position.
+	 * @tparam Position3Type Numeric type used for the coordinates.
+	 *
+	 * Inherits from Position2 (x, y coordinates) and extends it with 'z'.
 	 */
 	template<class Position3Type>
-	class Position3 : public Position2<Position3Type>{
+	class Position3 : virtual public Position2<Position3Type>{
 		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'x', 'y' and 'z' values.
-			 * @return: None.
+			/**
+			 * @brief Constructor that initializes the object with the given `x`, `y`, and `z` values.
+			 * @param x The initial value for the x coordinate (default = 0).
+			 * @param y The initial value for the y coordinate (default = 0).
+			 * @param z The initial value for the z coordinate (default = 0).
 			 */
 			Position3(Position3Type x = 0, Position3Type y = 0, Position3Type z = 0);
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
+			/**
+			 * @brief Virtual destructor.
 			 */
-			~Position3();
+			virtual ~Position3() = default;
 
-		public:
-			Position3Type z;
+			/**
+			 * @brief Get the z coordinate.
+			 * @return Reference to the current value of z.
+			 */
+			inline Position3Type& getZ();
+
+			/**
+			 * @brief Get the z coordinate (read-only for const objects).
+			 * @return Constant reference to z.
+			 */
+			inline const Position3Type& getZ() const;
+
+			/**
+			 * @brief Set the z coordinate.
+			 * @param z The value to assign to z.
+			 */
+			inline void setZ(const Position3Type& z);
 	};
 
-	typedef Position3<int> Position3i;
+	typedef Position3<int> Position3i; ///< Typedef for integer 3D positions.
 }
 
 template<class Position3Type>
 EToolkit::Position3<Position3Type>::Position3(Position3Type x, Position3Type y, Position3Type z) :
-	Position2<Position3Type>(x, y), z(z){
-
+	StaticArray<Position3Type>(3), Position2<Position3Type>(x, y){
+	(*this)[0] = x;
+	(*this)[1] = y;
+	(*this)[2] = z;
 }
 
 template<class Position3Type>
-EToolkit::Position3<Position3Type>::~Position3(){
+inline Position3Type& EToolkit::Position3<Position3Type>::getZ(){
+	return (*this)[2];
+}
 
+template<class Position3Type>
+inline const Position3Type& EToolkit::Position3<Position3Type>::getZ() const{
+    return (*this)[2];
+}
+
+template<class Position3Type>
+inline void EToolkit::Position3<Position3Type>::setZ(const Position3Type& z){
+	(*this)[2] = z;
 }
 
 #endif /* EPOSITION3_HPP */

--- a/source/geometry/ESize1.hpp
+++ b/source/geometry/ESize1.hpp
@@ -1,46 +1,81 @@
+/**
+ * @file Size1.hpp
+ * @brief Contains Size1 template class.
+ */
+
 #ifndef ESIZE1_HPP
 #define ESIZE1_HPP
 
+#include <EContainer>
+
 /*
- * @description: Evandro's C++ Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent 1 dimensional size.
-	 * @note: 'Size1Type' must be numeric.
+	/**
+	 * @class Size1
+	 * @brief Represents a 1-dimensional size (width).
+	 * @tparam Size1Type Numeric type used for the dimension.
+	 *
+	 * Inherits from StaticArray with size 1. Provides access to the single dimension 'width'.
 	 */
 	template<class Size1Type>
-	class Size1{
+	class Size1 : virtual public StaticArray<Size1Type>{
 		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'width' value.
-			 * @return: None.
+			/**
+			 * @brief Constructor that initializes the object with the given width.
+			 * @param width Initial width value (default = 0).
 			 */
 			Size1(Size1Type width = 0);
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
+			/**
+			 * @brief Virtual destructor.
 			 */
-			~Size1();
+			virtual ~Size1() = default;
 
-		public:
-			Size1Type width;
+			/**
+			 * @brief Get the width.
+			 * @return Reference to the width value.
+			 */
+			inline Size1Type& getWidth();
+
+		    /**
+		     * @brief Get the width (read-only for const objects).
+		     * @return Constant reference to width.
+		     */
+		    inline const Size1Type& getWidth() const;
+
+			/**
+			 * @brief Set the width.
+			 * @param width The value to assign as width.
+			 */
+			inline void setWidth(const Size1Type& width);
 	};
 
-	typedef Size1<int> Size1i;
+	typedef Size1<int> Size1i; ///< Typedef for integer 1D size.
 }
 
 template<class Size1Type>
 EToolkit::Size1<Size1Type>::Size1(Size1Type width) :
-	width(width){
-
+	StaticArray<Size1Type>(1){
+	(*this)[0] = width;
 }
 
 template<class Size1Type>
-EToolkit::Size1<Size1Type>::~Size1(){
+inline Size1Type& EToolkit::Size1<Size1Type>::getWidth(){
+	return (*this)[0];
+}
 
+template<class Size1Type>
+inline const Size1Type& EToolkit::Size1<Size1Type>::getWidth() const{
+    return (*this)[0];
+}
+
+template<class Size1Type>
+inline void EToolkit::Size1<Size1Type>::setWidth(const Size1Type& width){
+	(*this)[0] = width;
 }
 
 #endif /* ESIZE1_HPP */

--- a/source/geometry/ESize2.hpp
+++ b/source/geometry/ESize2.hpp
@@ -1,48 +1,83 @@
+/**
+ * @file Size2.hpp
+ * @brief Contains Size2 template class.
+ */
+
 #ifndef ESIZE2_HPP
 #define ESIZE2_HPP
 
 #include "ESize1.hpp"
 
 /*
- * @description: Evandro's C++ Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent 2 dimensional size.
-	 * @note: 'Size2Type' must be numeric.
+	/**
+	 * @class Size2
+	 * @brief Represents a 2-dimensional size (width, height).
+	 * @tparam Size2Type Numeric type used for the dimensions.
+	 *
+	 * Inherits from Size1 (width) and extends it with 'height'.
 	 */
 	template<class Size2Type>
-	class Size2 : public Size1<Size2Type>{
+	class Size2 : virtual public Size1<Size2Type>{
 		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'width' and 'height' values.
-			 * @return: None.
+			/**
+			 * @brief Constructor that initializes the object with width and height.
+			 * @param width Initial width (default = 0).
+			 * @param height Initial height (default = 0).
 			 */
 			Size2(Size2Type width = 0, Size2Type height = 0);
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
+			/**
+			 * @brief Virtual destructor.
 			 */
-			~Size2();
+			virtual ~Size2() = default;
 
-		public:
-			Size2Type height;
+			/**
+			 * @brief Get the height.
+			 * @return Reference to the height value.
+			 */
+			inline Size2Type& getHeight();
+
+		    /**
+		     * @brief Get the height (read-only for const objects).
+		     * @return Constant reference to height.
+		     */
+		    inline const Size2Type& getHeight() const;
+
+			/**
+			 * @brief Set the height.
+			 * @param height The value to assign as height.
+			 */
+			inline void setHeight(const Size2Type& height);
 	};
 
-	typedef Size2<int> Size2i;
+	typedef Size2<int> Size2i; ///< Typedef for integer 2D size.
 }
 
 template<class Size2Type>
 EToolkit::Size2<Size2Type>::Size2(Size2Type width, Size2Type height) :
-	Size1<Size2Type>(width), height(height){
-
+	StaticArray<Size2Type>(2), Size1<Size2Type>(width){
+	(*this)[0] = width;
+	(*this)[1] = height;
 }
 
 template<class Size2Type>
-EToolkit::Size2<Size2Type>::~Size2(){
+inline Size2Type& EToolkit::Size2<Size2Type>::getHeight(){
+	return (*this)[1];
+}
 
+template<class Size2Type>
+inline const Size2Type& EToolkit::Size2<Size2Type>::getHeight() const{
+    return (*this)[1];
+}
+
+template<class Size2Type>
+inline void EToolkit::Size2<Size2Type>::setHeight(const Size2Type& height){
+	(*this)[1] = height;
 }
 
 #endif /* ESIZE2_HPP */

--- a/source/geometry/ESize3.hpp
+++ b/source/geometry/ESize3.hpp
@@ -1,48 +1,85 @@
+/**
+ * @file Size3.hpp
+ * @brief Contains Size3 template class.
+ */
+
 #ifndef ESIZE3_HPP
 #define ESIZE3_HPP
 
 #include "ESize2.hpp"
 
 /*
- * @description: Evandro's C++ Toolkit.
+ * @namespace EToolkit
+ * @brief: Evandro's Toolkit.
  */
 namespace EToolkit{
 
-	/*
-	 * @description: Class that represent 2 dimensional size.
-	 * @note: 'Size3Type' must be numeric.
+	/**
+	 * @class Size3
+	 * @brief Represents a 3-dimensional size (width, height, depth).
+	 * @tparam Size3Type Numeric type used for the dimensions.
+	 *
+	 * Inherits from Size2 (width, height) and extends it with 'depth'.
 	 */
 	template<class Size3Type>
-	class Size3 : public Size2<Size3Type>{
+	class Size3 : virtual public Size2<Size3Type>{
 		public:
-			/*
-			 * @description: Default constructor that initialize object with the given 'width', 'height' and 'depth' values.
-			 * @return: None.
+			/**
+			 * @brief Constructor that initializes the object with width, height, and depth.
+			 * @param width Initial width (default = 0).
+			 * @param height Initial height (default = 0).
+			 * @param depth Initial depth (default = 0).
 			 */
 			Size3(Size3Type width = 0, Size3Type height = 0, Size3Type depth = 0);
 
-			/*
-			 * @description: Default destructor.
-			 * @return: None.
+			/**
+			 * @brief Virtual destructor.
 			 */
-			~Size3();
+			virtual ~Size3() = default;
 
-		public:
-			Size3Type depth;
+			/**
+			 * @brief Get the depth.
+			 * @return Reference to the depth value.
+			 */
+			inline Size3Type& getDepth();
+
+		    /**
+		     * @brief Get the depth (read-only for const objects).
+		     * @return Constant reference to depth.
+		     */
+		    inline const Size3Type& getDepth() const;
+
+			/**
+			 * @brief Set the depth.
+			 * @param depth The value to assign as depth.
+			 */
+			inline void setDepth(const Size3Type& depth);
 	};
 
-	typedef Size3<int> Size3i;
+	typedef Size3<int> Size3i; ///< Typedef for integer 3D size.
 }
 
 template<class Size3Type>
 EToolkit::Size3<Size3Type>::Size3(Size3Type width, Size3Type height, Size3Type depth) :
-	Size2<Size3Type>(width, height), depth(depth){
-
+	StaticArray<Size3Type>(3), Size2<Size3Type>(width, height){
+	(*this)[0] = width;
+	(*this)[1] = height;
+	(*this)[2] = depth;
 }
 
 template<class Size3Type>
-EToolkit::Size3<Size3Type>::~Size3(){
+inline Size3Type& EToolkit::Size3<Size3Type>::getDepth(){
+	return (*this)[2];
+}
 
+template<class Size3Type>
+inline const Size3Type& EToolkit::Size3<Size3Type>::getDepth() const{
+    return (*this)[2];
+}
+
+template<class Size3Type>
+inline void EToolkit::Size3<Size3Type>::setDepth(const Size3Type& depth){
+	(*this)[2] = depth;
 }
 
 #endif /* ESIZE3_HPP */


### PR DESCRIPTION
- Refactor StaticArray and unify Position, Size, and Bounds hierarchies.
- Added const operator[] to StaticArray.
- Updated all Position1/2/3 , Size1/2/3, and Bounds1/2/3 to be fully compatible and inherit virtually from StaticArray.
- Virtual inheritance ensures a single contiguous memory block per object.
- Supports all dimensions consistently.